### PR TITLE
CBP-19247: Upgrade Go to 1.25.4 to fix CVE-2025-4674

### DIFF
--- a/.cloudbees/workflows/workflow.yaml
+++ b/.cloudbees/workflows/workflow.yaml
@@ -21,14 +21,14 @@ jobs:
 
     - id: unit-test
       name: Unit tests
-      uses: docker://golang:1.24
+      uses: docker://golang:1.25.4
       run: |
         go version
         make test
 
     - id: lint
       name: Lint
-      uses: docker://golang:1.24
+      uses: docker://golang:1.25.4
       run: |
         go version
         make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,76 +1,65 @@
-# https://golangci-lint.run/usage/configuration/#output-configuration
+version: "2"
+
 output:
   sort-order:
     - file
     - linter
-  sort-results: true
   show-stats: true
 
-# https://golangci-lint.run/usage/configuration/#linters-configuration
 linters:
-  # https://golangci-lint.run/usage/linters/
-  enable-all: true
+  default: all
   disable:
-    - execinquery # deprecated
-    - gomnd # deprecated
-    - gochecknoglobals # Check that no global variables exist.
-    - wrapcheck # https://golangci-lint.run/usage/linters/#wrapcheck
-    - depguard # https://golangci-lint.run/usage/linters/#depguard
-    - exhaustruct # https://golangci-lint.run/usage/linters/#exhaustruct
-    - gci # https://golangci-lint.run/usage/linters/#gci
-    - gochecknoinits # Checks that no init functions are present in Go code.
-    - godox # https://golangci-lint.run/usage/linters/#godox
-    - mnd # https://golangci-lint.run/usage/linters/#mnd
-    - err113 # Go linter to check the errors handling expressions.
-    - ireturn # https://golangci-lint.run/usage/linters/#ireturn
-    - gomoddirectives # https://golangci-lint.run/usage/linters/#gomoddirectives
-    - tagliatelle # https://golangci-lint.run/usage/linters/#tagliatelle (We use kebab and snake for json tags, linter does not support multiple cases yet)
-    - gofumpt # https://golangci-lint.run/usage/linters/#gofumpt
+    - execinquery
+    - gomnd
+    - gochecknoglobals
+    - wrapcheck
+    - depguard
+    - exhaustruct
+    - gochecknoinits
+    - godox
+    - mnd
+    - err113
+    - ireturn
+    - gomoddirectives
+    - tagliatelle
+  
+  settings:
+    cyclop:
+      max-complexity: 15
+    gosec:
+      excludes:
+        - G204
+        - G306
+    varnamelen:
+      max-distance: 10
+      ignore-names:
+        - ok
+        - wf
+        - ch
+        - i
+        - fn
+      ignore-decls:
+        - r interface{}
+    perfsprint:
+      strconcat: false
+    nestif:
+      min-complexity: 7
+    funlen:
+      ignore-comments: true
+      lines: 65
+    govet:
+      enable:
+        - shadow
+  
+  exclusions:
+    paths:
+      - ".*_test\\.go"
+      - "fake_.*\\.go"
+      - "fake/"
+    generated: strict
 
-linters-settings:
-  # https://golangci-lint.run/usage/linters/#cyclop
-  cyclop:
-    # The maximal code complexity to report.
-    # Default: 10
-    max-complexity: 15
-  gosec:
-    # https://golangci-lint.run/usage/linters/#gosec
-    excludes:
-      - G204 # Audit use of command execution
-      - G306 # Poor file permissions used when creating a file
-  varnamelen:
-    # https://golangci-lint.run/usage/linters/#varnamelen
-    max-distance: 10
-    ignore-names:
-      - ok # used to check if a map key exists
-      - wf # used for workflow reference
-      - ch # channel names
-      - i # index
-      - fn # variable representing a function
-    ignore-decls:
-      - r interface{}
-  perfsprint:
-    # https://golangci-lint.run/usage/linters/#perfsprint
-    strconcat: false
-  nestif:
-    # https://golangci-lint.run/usage/linters/#nestif
-    min-complexity: 7
-  funlen:
-    # https://golangci-lint.run/usage/linters/#funlen
-    ignore-comments: true
-    lines: 65
-  govet:
-    enable:
-      # Disallow shadowing variables to prevent the following problems that are not caught by the Go compiler:
-      # * Having both a global and local variable with the same name can cause problems that manifest themselves after a simple refactoring moving code from one place to another.
-      # * Redeclaring `err` within a code block may result in the previous err value being ignored silently.
-      - shadow
-
-# https://golangci-lint.run/usage/configuration/#issues-configuration
-issues:
-  # exclude test files
-  exclude-files:
-    - ".*_test\\.go"
-    - "fake_.*\\.go"
-  exclude-dirs:
-    - "fake"
+formatters:
+  default: all
+  disable:
+    - gci
+    - gofumpt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,8 +9,6 @@ output:
 linters:
   default: all
   disable:
-    - execinquery
-    - gomnd
     - gochecknoglobals
     - wrapcheck
     - depguard

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine3.21 AS build
+FROM golang:1.25.4-alpine3.21 AS build
 COPY go.mod go.sum /src/
 WORKDIR /src
 RUN go mod download

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 VERSION ?= dev
 
-GOLANGCI_LINT_VERSION := v1.64.8
+GOLANGCI_LINT_VERSION := v2.6.2
 
 
 all: cli

--- a/cmd/registry-config/convert.go
+++ b/cmd/registry-config/convert.go
@@ -1,3 +1,4 @@
+// Package main provides the registry-config command-line tool.
 package main
 
 import (

--- a/cmd/registry-config/convert.go
+++ b/cmd/registry-config/convert.go
@@ -34,7 +34,7 @@ func convertRegistriesConfig(_ *cobra.Command, args []string) (err error) {
 
 	rhConfig := convert.ToRegistriesConf(config)
 
-	outFile, err := os.OpenFile(args[0], os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0640)
+	outFile, err := os.OpenFile(args[0], os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
 	if err != nil {
 		return fmt.Errorf("write registries.conf: %w", err)
 	}

--- a/cmd/registry-config/resolve.go
+++ b/cmd/registry-config/resolve.go
@@ -38,6 +38,7 @@ func resolveImageReference(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
 	defer func() {
 		_ = resolver.Close()
 	}()
@@ -50,7 +51,7 @@ func resolveImageReference(_ *cobra.Command, args []string) error {
 	output := strings.Join(locations, "\n")
 
 	if len(args) == 2 && args[1] != "-" {
-		err := writeToFile(args[1], []byte(output+"\n"))
+		err = writeToFile(args[1], []byte(output+"\n"))
 		if err != nil {
 			return fmt.Errorf("write registries.conf: %w", err)
 		}
@@ -64,6 +65,7 @@ func resolveImageReference(_ *cobra.Command, args []string) error {
 }
 
 func writeToFile(path string, content []byte) (err error) {
+	// #nosec G304 -- path is validated by caller
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
 	if err != nil {
 		return err

--- a/cmd/registry-config/resolve.go
+++ b/cmd/registry-config/resolve.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -65,8 +66,8 @@ func resolveImageReference(_ *cobra.Command, args []string) error {
 }
 
 func writeToFile(path string, content []byte) (err error) {
-	// #nosec G304 -- path is validated by caller
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	cleanPath := filepath.Clean(path)
+	file, err := os.OpenFile(cleanPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
 	if err != nil {
 		return err
 	}

--- a/cmd/registry-config/resolve.go
+++ b/cmd/registry-config/resolve.go
@@ -67,6 +67,7 @@ func resolveImageReference(_ *cobra.Command, args []string) error {
 
 func writeToFile(path string, content []byte) (err error) {
 	cleanPath := filepath.Clean(path)
+
 	file, err := os.OpenFile(cleanPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
 	if err != nil {
 		return err

--- a/cmd/registry-config/resolve.go
+++ b/cmd/registry-config/resolve.go
@@ -38,7 +38,9 @@ func resolveImageReference(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer resolver.Close()
+	defer func() {
+		_ = resolver.Close()
+	}()
 
 	locations, err := resolver.Resolve(args[0])
 	if err != nil {
@@ -56,13 +58,13 @@ func resolveImageReference(_ *cobra.Command, args []string) error {
 		return nil
 	}
 
-	fmt.Fprintln(stdout, output)
+	_, err = fmt.Fprintln(stdout, output)
 
-	return nil
+	return err
 }
 
 func writeToFile(path string, content []byte) (err error) {
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0640)
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudbees-io/registry-config
 
-go 1.24.2
+go 1.25.4
 
 require (
 	github.com/BurntSushi/toml v1.3.2

--- a/pkg/convert/convert.go
+++ b/pkg/convert/convert.go
@@ -1,3 +1,4 @@
+// Package convert provides functions to convert registry configurations between formats.
 package convert
 
 import (

--- a/pkg/registries/load.go
+++ b/pkg/registries/load.go
@@ -10,6 +10,7 @@ import (
 
 // LoadConfig loads the registry mirror configuration file.
 func LoadConfig(file string) (Config, error) {
+	// #nosec G304 -- file path is provided by caller/config
 	raw, err := os.ReadFile(file)
 	if err != nil {
 		return Config{}, fmt.Errorf("load registries config: %w", err)

--- a/pkg/registries/load.go
+++ b/pkg/registries/load.go
@@ -6,12 +6,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 // LoadConfig loads the registry mirror configuration file.
 func LoadConfig(file string) (Config, error) {
-	// #nosec G304 -- file path is provided by caller/config
-	raw, err := os.ReadFile(file)
+	cleanFile := filepath.Clean(file)
+	raw, err := os.ReadFile(cleanFile)
 	if err != nil {
 		return Config{}, fmt.Errorf("load registries config: %w", err)
 	}

--- a/pkg/registries/load.go
+++ b/pkg/registries/load.go
@@ -12,6 +12,7 @@ import (
 // LoadConfig loads the registry mirror configuration file.
 func LoadConfig(file string) (Config, error) {
 	cleanFile := filepath.Clean(file)
+
 	raw, err := os.ReadFile(cleanFile)
 	if err != nil {
 		return Config{}, fmt.Errorf("load registries config: %w", err)

--- a/pkg/registries/load.go
+++ b/pkg/registries/load.go
@@ -1,3 +1,4 @@
+// Package registries provides functionality to load and manage registry configurations.
 package registries
 
 import (
@@ -14,7 +15,7 @@ func LoadConfig(file string) (Config, error) {
 		return Config{}, fmt.Errorf("load registries config: %w", err)
 	}
 
-	m := map[string]interface{}{}
+	m := map[string]any{}
 
 	err = json.Unmarshal(raw, &m)
 	if err != nil {

--- a/pkg/resolve/resolver.go
+++ b/pkg/resolve/resolver.go
@@ -97,6 +97,7 @@ func createTempRegistriesConf(config registries.Config) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	defer func() {
 		_ = tmpFile.Close()
 	}()

--- a/pkg/resolve/resolver.go
+++ b/pkg/resolve/resolver.go
@@ -1,3 +1,4 @@
+// Package resolve provides image reference resolution using registry mirror configurations.
 package resolve
 
 import (
@@ -17,20 +18,6 @@ type Resolver struct {
 	config *types.SystemContext
 }
 
-// Close closes the resolver.
-func (r *Resolver) Close() error {
-	if r.config != nil {
-		err := os.Remove(r.config.SystemRegistriesConfPath)
-		if err != nil && !os.IsNotExist(err) {
-			return err
-		}
-
-		r.config = nil
-	}
-
-	return nil
-}
-
 // NewResolver creates a new image reference resolver using the provided config.
 func NewResolver(config registries.Config) (*Resolver, error) {
 	tmpRhConfFile, err := createTempRegistriesConf(config)
@@ -43,6 +30,20 @@ func NewResolver(config registries.Config) (*Resolver, error) {
 			SystemRegistriesConfPath: tmpRhConfFile,
 		},
 	}, nil
+}
+
+// Close closes the resolver.
+func (r *Resolver) Close() error {
+	if r.config != nil {
+		err := os.Remove(r.config.SystemRegistriesConfPath)
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+
+		r.config = nil
+	}
+
+	return nil
 }
 
 // Resolve returns a list of (mirror) locations for the given image reference.
@@ -96,9 +97,12 @@ func createTempRegistriesConf(config registries.Config) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer tmpFile.Close()
+	defer func() {
+		_ = tmpFile.Close()
+	}()
 
-	if err = convert.Write(rhRegistriesConf, tmpFile); err != nil {
+	err = convert.Write(rhRegistriesConf, tmpFile)
+	if err != nil {
 		_ = os.Remove(tmpFile.Name())
 
 		return "", err


### PR DESCRIPTION
## CBP-19247: Upgrade Go to 1.25.4 to fix CVE-2025-4674

### Changes
- **Go Version Upgrade**: Updated from Go 1.24.2 to 1.25.4 to address CVE-2025-4674 (High severity, CVSS 8.6) which affects the go command in untrusted VCS repositories
- **Linter Upgrade Required**: golangci-lint v1.64.8 does not support Go 1.25.x; upgraded to v2.6.2 which includes Go 1.25 support (added in v2.4.0)
- **Configuration Migration**: golangci-lint v2.x uses incompatible config format from v1.x; migrated `.golangci.yml` to v2 schema (removed deprecated linters, restructured settings, separated formatters section)
- **Code Quality Fixes**: Resolved linting issues exposed by stricter v2.x rules including missing package comments, unchecked error returns, file permission security warnings (G302/G304), variable shadowing, and function ordering
- **Verification**: All unit tests pass (77.6-90.9% coverage) and linting passes with 0 issues

## Why Update registry-config Repo for CBP-19247
- The ticket is for helm-install but the vulnerable component is found in Dockerfile which comes from registry-config repo, hence first we have to update this repo and then use it in Dockerfile of helm-install repo as commented [here](https://cloudbees.atlassian.net/browse/CBP-19247?focusedCommentId=1216647)

- I tried with only Dockerfile update but due version mismatch, had to update lint, which then enforced actual code changes, due to more improvements in latest lint version which I updated lint to now.