### PR TITLE
[CBP-45084] switch to build/action@v8 (action variant)

### DIFF
--- a/.cloudbees/workflows/workflow.yaml
+++ b/.cloudbees/workflows/workflow.yaml
@@ -37,7 +37,7 @@ jobs:
     - id: build-image
       name: Build, scan and push to ECR
       if: ${{ vars.workflow_execution_env == 'production' }}
-      uses: calculi-corp/cb-internal-shared-actions/build@v8
+      uses: calculi-corp/cb-internal-shared-actions/build/action@v8
       with:
         go-binary-build: "false"
         kaniko-build: "true"


### PR DESCRIPTION
Switch this repo from `calculi-corp/cb-internal-shared-actions/build@v8`
(services variant) to `build/action@v8` (action variant) — the variant
intended for cloudbees-io action repos.

Follows the pattern Kirk established in
[cloudbees-io/configure-oci-credentials#33](https://github.com/cloudbees-io/configure-oci-credentials/pull/33).
The producer side (clean `image:${gitsha}` tag prepended to the destination
list) shipped in
[calculi-corp/cb-internal-shared-actions#123](https://github.com/calculi-corp/cb-internal-shared-actions/pull/123).

### Edits applied

- `.cloudbees/workflows/workflow.yaml`: `build@v8` → `build/action@v8`

### Edits NOT applied (already in good state)

- `permissions:` block already has `scm-token-org: read`.
- No `.cloudbees/testing/action.yml` in this repo.

Tracking: CBP-45084