### PR TITLE
[CBP-44775] Update workflow to use shared actions for golang build, bump golangci-lint config

### DIFF
--- a/.cloudbees/workflows/workflow.yaml
+++ b/.cloudbees/workflows/workflow.yaml
@@ -23,7 +23,7 @@ jobs:
     - id: build-image
       name: Build, scan and push to ECR
       if: ${{ vars.workflow_execution_env == 'production' }}
-      uses: calculi-corp/cb-internal-shared-actions/build/action@make-go-build-more-flexible
+      uses: calculi-corp/cb-internal-shared-actions/build/action@v8
       with:
         go-binary-build: "true"
         go-build-ldflags: "-X main.version=${{ cloudbees.version }}"

--- a/.cloudbees/workflows/workflow.yaml
+++ b/.cloudbees/workflows/workflow.yaml
@@ -37,12 +37,14 @@ jobs:
     - id: build-image
       name: Build, scan and push to ECR
       if: ${{ vars.workflow_execution_env == 'production' }}
-      uses: calculi-corp/cb-internal-shared-actions/build/action@v8
+      uses: calculi-corp/cb-internal-shared-actions/build/action@make-go-build-more-flexible
       with:
-        go-binary-build: "false"
+        go-binary-build: "true"
+        go-build-ldflags: "-X main.version=${{ cloudbees.version }}"
+        go-build-main: "./cmd/registry-config"
+        go-binary-name: "registry-config"
         kaniko-build: "true"
         run-unit-test: "false"
-        build-args: VERSION=${{ cloudbees.version }}
         registry-url: 020229604682.dkr.ecr.us-east-1.amazonaws.com
         registry-image-name: actions/registry-config
         registry-type: ECR

--- a/.cloudbees/workflows/workflow.yaml
+++ b/.cloudbees/workflows/workflow.yaml
@@ -44,7 +44,8 @@ jobs:
         go-build-main: "./cmd/registry-config"
         go-binary-name: "registry-config"
         kaniko-build: "true"
-        run-unit-test: "false"
+        run-unit-test: "true"
+        golangci-lint: "true"
         registry-url: 020229604682.dkr.ecr.us-east-1.amazonaws.com
         registry-image-name: actions/registry-config
         registry-type: ECR

--- a/.cloudbees/workflows/workflow.yaml
+++ b/.cloudbees/workflows/workflow.yaml
@@ -20,20 +20,6 @@ jobs:
       name: Get source code
       uses: cloudbees-io/checkout@v1
 
-    - id: unit-test
-      name: Unit tests
-      uses: docker://golang:1.26.3
-      run: |
-        go version
-        make test
-
-    - id: lint
-      name: Lint
-      uses: docker://golang:1.26.3
-      run: |
-        go version
-        make lint
-
     - id: build-image
       name: Build, scan and push to ECR
       if: ${{ vars.workflow_execution_env == 'production' }}

--- a/.cloudbees/workflows/workflow.yaml
+++ b/.cloudbees/workflows/workflow.yaml
@@ -22,14 +22,14 @@ jobs:
 
     - id: unit-test
       name: Unit tests
-      uses: docker://golang:1.26.2
+      uses: docker://golang:1.26.3
       run: |
         go version
         make test
 
     - id: lint
       name: Lint
-      uses: docker://golang:1.26.2
+      uses: docker://golang:1.26.3
       run: |
         go version
         make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,10 @@ output:
 
 linters:
   default: all
+  enable:
+    - wsl_v5
   disable:
+    - wsl
     - gochecknoglobals
     - wrapcheck
     - depguard
@@ -22,6 +25,10 @@ linters:
     - tagliatelle
   
   settings:
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 2
     cyclop:
       max-complexity: 15
     gosec:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,4 @@
-FROM golang:1.26.3-alpine3.23 AS build
-COPY go.mod go.sum /src/
-WORKDIR /src
-RUN go mod download
-COPY . /src/
-ENV CGO_ENABLED=0
-ARG VERSION=dev
-RUN go build -a -ldflags '-X main.version=$VERSION -w -extldflags "-static"' -o registry-config ./cmd/registry-config
-
 FROM gcr.io/distroless/static:nonroot
-COPY --from=build /src/registry-config /registry-config
+COPY registry-config /registry-config
 COPY ./pkg/registries/testdata/registries.json /etc/cloudbees/registries.json
 ENTRYPOINT ["/registry-config"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-alpine3.23 AS build
+FROM golang:1.26.3-alpine3.23 AS build
 COPY go.mod go.sum /src/
 WORKDIR /src
 RUN go mod download

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 VERSION ?= dev
 
-GOLANGCI_LINT_VERSION := v2.10.1
+GOLANGCI_LINT_VERSION := v2.11.4
 
 
 all: cli

--- a/pkg/resolve/resolver.go
+++ b/pkg/resolve/resolver.go
@@ -104,9 +104,8 @@ func createTempRegistriesConf(config registries.Config) (string, error) {
 
 	err = convert.Write(rhRegistriesConf, tmpFile)
 	if err != nil {
-		//nolint:gosec // G703: Safe - tmpFile.Name() comes from os.CreateTemp(), not user input
+		// G703: Safe - tmpFile.Name() comes from os.CreateTemp(), not user input
 		_ = os.Remove(tmpFile.Name())
-
 		return "", err
 	}
 

--- a/pkg/resolve/resolver.go
+++ b/pkg/resolve/resolver.go
@@ -106,6 +106,7 @@ func createTempRegistriesConf(config registries.Config) (string, error) {
 	if err != nil {
 		// G703: Safe - tmpFile.Name() comes from os.CreateTemp(), not user input
 		_ = os.Remove(tmpFile.Name())
+
 		return "", err
 	}
 


### PR DESCRIPTION
Update registry-config build workflow to build the golang binary using the shared actions (with the new build-go-root, build-go-ldflags support) so the common golang version is in use to allow for automated rebuilds.

Update version of golangci-lint to match shared actions
Move lint and unit tests to shared actions
Cleanup Dockerfile so it doesnt build golang binary anymore