### PR TITLE
fix: change create-upgrade-pr to use scm.sha for tag to update in pla…

### DIFF
--- a/.cloudbees/workflows/workflow.yaml
+++ b/.cloudbees/workflows/workflow.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           component: registry-config
           artifact-key: public.actions.registry-config
-          artifact-value: ${{ cloudbees.version }}
+          artifact-value: ${{ cloudbees.scm.sha }}
           app-id: ${{ vars.platform_helmfiles_app_id }}
           installation-id: ${{ vars.platform_helmfiles_installation_id }}
           private-key-b64: ${{ secrets.platform_helmfiles_gh_app_key_b64 }}


### PR DESCRIPTION
…tform-helmfiles

Shared actions do not create the cloudbees.version image tags for actions, so best solution is to update to the git sha for the image tag

WIll also require updating the helm-install action to use either the sha image tag or to use an image digest